### PR TITLE
fix typos and replace \code{} by markdown tags

### DIFF
--- a/R/rl_assessment.R
+++ b/R/rl_assessment.R
@@ -1,6 +1,6 @@
 #' Retrieve an assessment
 #'
-#' Get the full details for a single IUCN Red List assessment
+#' Get the full details for a single IUCN Red List assessment.
 #'
 #' @export
 #' @param id (integer) The unique identifier of the assessment.

--- a/R/rl_citation.R
+++ b/R/rl_citation.R
@@ -5,9 +5,9 @@
 #' List API. More details are available here: <https://api.iucnredlist.org/>.
 #'
 #' @export
-#' @param key (character) An IUCN API token. See \code{\link{rl_use_iucn}}.
-#' @param ... Curl options passed to \code{\link[crul]{HttpClient}}
-#' @return Red List citation as character string
+#' @param key (character) An IUCN API token. See [rl_use_iucn()].
+#' @param ... Curl options passed to [HttpClient][crul::HttpClient()].
+#' @return Red List citation as character string.
 #' @family stats
 #' @examples \dontrun{
 #' rl_citation()

--- a/R/rl_comp_groups.R
+++ b/R/rl_comp_groups.R
@@ -1,6 +1,6 @@
 #' Comprehensive group assessment summary
 #'
-#' Returns a list of the latest assessments for an comprehensive group name
+#' Returns a list of the latest assessments for a comprehensive group name.
 #'
 #' @export
 #' @param name (character) The code of the comprehensive group to look up. If

--- a/R/rl_countries.R
+++ b/R/rl_countries.R
@@ -1,6 +1,6 @@
 #' Country assessment summary
 #'
-#' Returns a collection of assessments for a given country code
+#' Returns a collection of assessments for a given country code.
 #'
 #' @export
 #' @param code (character) The ISO alpha-2 code of the country to look up. If

--- a/R/rl_realms.R
+++ b/R/rl_realms.R
@@ -1,7 +1,7 @@
 #' Biogeographical realm assessment summary
 #'
 #' Get an assessment summary for a particular biogeographical realm (e.g.,
-#' Neotropical or Palearctic)
+#' Neotropical or Palearctic).
 #'
 #' @export
 #' @param code (character) The code of the biogeographical realm to look up. If

--- a/R/rl_sp_count.R
+++ b/R/rl_sp_count.R
@@ -1,10 +1,10 @@
 #' Get count of species in the Red List
 #'
-#' Returns a count of the number of unique species which have assessments
+#' Returns a count of the number of unique species which have assessments.
 #'
 #' @export
-#' @param key (character) An IUCN API token. See \code{\link{rl_use_iucn}}.
-#' @param ... Curl options passed to \code{\link[crul]{HttpClient}}
+#' @param key (character) An IUCN API token. See [rl_use_iucn()].
+#' @param ... Curl options passed to [HttpClient][crul::HttpClient()]
 #' @template info
 #' @family stats
 #' @examples \dontrun{

--- a/R/rl_version.R
+++ b/R/rl_version.R
@@ -1,12 +1,12 @@
 #' Get the Red List API version
 #'
 #' Returns the current version number of the IUCN Red List of Threatened Species
-#' API
+#' API.
 #'
 #' @export
-#' @param key (character) An IUCN API token. See \code{\link{rl_use_iucn}}.
-#' @param ... Curl options passed to \code{\link[crul]{HttpClient}}
-#' @return API version as character string
+#' @param key (character) An IUCN API token. See [rl_use_iucn()].
+#' @param ... Curl options passed to [HttpClient][crul::HttpClient()].
+#' @return API version as character string.
 #' @family stats
 #' @examples \dontrun{
 #' rl_api_version()
@@ -21,9 +21,9 @@ rl_api_version <- function(key = NULL, ...) {
 #' Returns the current version number of the IUCN Red List of Threatened Species
 #'
 #' @export
-#' @param key (character) An IUCN API token. See \code{\link{rl_use_iucn}}.
-#' @param ... Curl options passed to \code{\link[crul]{HttpClient}}
-#' @return Red List version as character string
+#' @param key (character) An IUCN API token. See [rl_use_iucn()].
+#' @param ... Curl options passed to [HttpClient][crul::HttpClient()].
+#' @return Red List version as character string.
 #' @family stats
 #' @examples \dontrun{
 #' rl_version()

--- a/R/rredlist-package.R
+++ b/R/rredlist-package.R
@@ -8,7 +8,7 @@
 #' for help getting and storing it. Get it at
 #' https://api.iucnredlist.org/users/sign_up
 #' Keep this key private. You can pass the key in to each function via the
-#' `key` parameter, but it's better to store the key either as a
+#' `key` parameter, but it's better to store the key either as an
 #' environment variable (`IUCN_REDLIST_KEY`) or an R option
 #' (`iucn_redlist_key`) - we recommend using the former option.
 #'
@@ -16,21 +16,21 @@
 #' **High level API**
 #' High level functions do the HTTP request and parse data to a data.frame for
 #' ease of downstream use. The high level functions have no underscore on
-#' the end of the function name, e.g., [rl_species()]
+#' the end of the function name, e.g., [rl_species()].
 #'
 #' **Low level API**
 #' The parsing to data.frame in the high level API does take extra time.
 #' The low level API only does the HTTP request, and gives back JSON without
 #' doing any more parsing. The low level functions DO have an underscore on
-#' the end of the function name, e.g., [rl_species_()]
+#' the end of the function name, e.g., [rl_species_()].
 #'
 #' @section No Spatial:
 #' This package does not include support for the spatial API, described at
-#' https://apiv3.iucnredlist.org/spatial
+#' https://apiv3.iucnredlist.org/spatial.
 #'
 #' @section Citing the Red List API:
 #' Get the proper citation for the version of the Red List you are using
-#' by programatically running [rl_citation()]
+#' by programatically running [rl_citation()].
 #'
 #' @section Red List API Terms of Use:
 #' See https://www.iucnredlist.org/terms/terms-of-use

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,10 +21,10 @@ rredlist_ua <- function() {
 #' Build and handle a GET query of the IUCN API
 #'
 #' @param path (character) The full API endpoint.
-#' @param key (character) An IUCN API token. See \code{\link{rl_use_iucn}}.
+#' @param key (character) An IUCN API token. See [rl_use_iucn()].
 #' @param query (list) A list of parameters to include in the GET query.
 #' @param ... [Curl options][curl::curl_options()] passed to the GET request via
-#'   \code{\link[crul]{HttpClient}}.
+#'   [HttpClient][crul::HttpClient()].
 #'
 #' @noRd
 #' @return The response of the query as a JSON string.
@@ -74,8 +74,8 @@ err_catcher <- function(x) {
 #'
 #' @param x (character) A JSON string.
 #' @param parse (logical) Whether to parse sub-elements of the list to lists
-#'   (\code{FALSE}) or, where possible, to data.frames (\code{TRUE}). Default:
-#'   \code{TRUE}.
+#'   (`FALSE`) or, where possible, to data.frames (`TRUE`). Default:
+#'   `TRUE`.
 #'
 #' @return A list.
 #' @noRd
@@ -166,10 +166,10 @@ assert_not_na <- function(x) {
 #' @param res A list where each element represents the assessments from a single
 #'   page of a multi-page query (such as the output of `page_assessments()`).
 #' @param parse (logical) Whether to parse and combine the assessments into a
-#'   data.frame (\code{TRUE}) or keep them as lists (\code{FALSE}). Default:
-#'   \code{TRUE}.
+#'   data.frame (`TRUE`) or keep them as lists (`FALSE`). Default:
+#'   `TRUE`.
 #' @noRd
-#' @return If `parse` is \code{TRUE}, a data.frame, otherwise, a list.
+#' @return If `parse` is `TRUE`, a data.frame, otherwise, a list.
 combine_assessments <- function(res, parse) {
   if (length(res) <= 1) return(rl_parse(res, parse))
   lst <- lapply(res, rl_parse, parse = parse)
@@ -186,12 +186,12 @@ combine_assessments <- function(res, parse) {
 #' Page through assessments
 #'
 #' @param path (character) The full API endpoint.
-#' @param key (character) An IUCN API token. See \code{\link{rl_use_iucn}}.
+#' @param key (character) An IUCN API token. See [rl_use_iucn()].
 #' @param quiet (logical) Whether to suppress progress for multi-page downloads
 #'   or not. Default: `FALSE` (that is, give progress). Ignored if `all =
 #'   FALSE`.
 #' @param ... [Curl options][curl::curl_options()] passed to the GET request via
-#'   \code{\link[crul]{HttpClient}}.
+#'   [HttpClient][crul::HttpClient()].
 #'
 #' @return A list with each element representing the response of one page of
 #'   results.

--- a/man-roxygen/all.R
+++ b/man-roxygen/all.R
@@ -1,3 +1,3 @@
-#' @param key (character) An IUCN API token. See \code{\link{rl_use_iucn}}.
-#' @param parse (logical) Whether to parse the output to list (\code{FALSE}) or,
-#'   where possible, data.frame (\code{TRUE}). Default: \code{TRUE}
+#' @param key (character) An IUCN API token. See [rl_use_iucn()].
+#' @param parse (logical) Whether to parse the output to list (`FALSE`) or,
+#'   where possible, data.frame (`TRUE`). Default: `TRUE`.

--- a/man-roxygen/commonargs.R
+++ b/man-roxygen/commonargs.R
@@ -1,5 +1,5 @@
-#' @param name (character) A taxonomic name
-#' @param id (character) An IUCN identifier
-#' @param region (character) A region name, see \code{\link{rl_regions}} for
-#' acceptable region identifiers (use the entries in the \code{identifier}
-#' column)
+#' @param name (character) A taxonomic name.
+#' @param id (character) An IUCN identifier.
+#' @param region (character) A region name, see [rl_regions()] for
+#' acceptable region identifiers (use the entries in the `identifier`
+#' column).

--- a/man-roxygen/curl.R
+++ b/man-roxygen/curl.R
@@ -1,2 +1,2 @@
 #' @param ... [Curl options][curl::curl_options()] passed to the GET request via
-#'   \code{\link[crul]{HttpClient}}.
+#'   [cruls][crul::HttpClient()].

--- a/man-roxygen/filters.R
+++ b/man-roxygen/filters.R
@@ -3,14 +3,14 @@
 #'   docs](https://api.iucnredlist.org/api-docs/index.html) for more
 #'   information):
 #'   \itemize{
-#'     \item \code{year_published}: (integer) Set this to return only
+#'     \item `year_published`: (integer) Set this to return only
 #'       assessments from a given year.
-#'     \item \code{latest}: (logical) Set this to \code{TRUE} to return only the
+#'     \item `latest`: (logical) Set this to `TRUE` to return only the
 #'       latest assessment for each taxon.
-#'     \item \code{scope_code}: (integer) Set this to return only assessments
+#'     \item `scope_code`: (integer) Set this to return only assessments
 #'       from a particular [scope][rl_scopes()] (e.g., `1` for Global, `2` for
 #'       Europe). This is similar to the `region` argument of the old Red List
 #'       API and old versions of rredlist.
 #'   }
 #'   Also supports any [curl options][curl::curl_options()] passed to the GET
-#'   request via \code{\link[crul]{HttpClient}}.
+#'   request via [HttpClient][crul::HttpClient()].

--- a/man/rl_actions.Rd
+++ b/man/rl_actions.Rd
@@ -21,10 +21,10 @@ rl_actions_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the conservation action to look up. If
 not supplied, a list of all conservation actions will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_api_version.Rd
+++ b/man/rl_api_version.Rd
@@ -7,16 +7,16 @@
 rl_api_version(key = NULL, ...)
 }
 \arguments{
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
-\item{...}{Curl options passed to \code{\link[crul]{HttpClient}}}
+\item{...}{Curl options passed to \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
-API version as character string
+API version as character string.
 }
 \description{
 Returns the current version number of the IUCN Red List of Threatened Species
-API
+API.
 }
 \examples{
 \dontrun{

--- a/man/rl_assessment.Rd
+++ b/man/rl_assessment.Rd
@@ -12,20 +12,20 @@ rl_assessment_(id, key = NULL, ...)
 \arguments{
 \item{id}{(integer) The unique identifier of the assessment.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which
 case json as character string is returned.
 }
 \description{
-Get the full details for a single IUCN Red List assessment
+Get the full details for a single IUCN Red List assessment.
 }
 \examples{
 \dontrun{

--- a/man/rl_categories.Rd
+++ b/man/rl_categories.Rd
@@ -28,10 +28,10 @@ rl_categories_(
 \item{code}{(character) The code of the Red List category to look up. If not
 supplied, a list of all categories will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -58,7 +58,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_citation.Rd
+++ b/man/rl_citation.Rd
@@ -7,12 +7,12 @@
 rl_citation(key = NULL, ...)
 }
 \arguments{
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
-\item{...}{Curl options passed to \code{\link[crul]{HttpClient}}}
+\item{...}{Curl options passed to \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
-Red List citation as character string
+Red List citation as character string.
 }
 \description{
 Full acknowledgement and citation needs to be given for using the API. Use

--- a/man/rl_class.Rd
+++ b/man/rl_class.Rd
@@ -21,10 +21,10 @@ rl_class_(class = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{class}{(character) The name of the class to look up. If not supplied, a
 list of all class names will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_comp_groups.Rd
+++ b/man/rl_comp_groups.Rd
@@ -28,10 +28,10 @@ rl_comp_groups_(
 \item{name}{(character) The code of the comprehensive group to look up. If
 not supplied, a list of all comprehensive groups will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -58,14 +58,14 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which
 case json as character string is returned.
 }
 \description{
-Returns a list of the latest assessments for an comprehensive group name
+Returns a list of the latest assessments for a comprehensive group name.
 }
 \examples{
 \dontrun{

--- a/man/rl_countries.Rd
+++ b/man/rl_countries.Rd
@@ -28,10 +28,10 @@ rl_countries_(
 \item{code}{(character) The ISO alpha-2 code of the country to look up. If
 not supplied, a list of all countries will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -58,14 +58,14 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which
 case json as character string is returned.
 }
 \description{
-Returns a collection of assessments for a given country code
+Returns a collection of assessments for a given country code.
 }
 \examples{
 \dontrun{

--- a/man/rl_extinct.Rd
+++ b/man/rl_extinct.Rd
@@ -10,10 +10,10 @@ rl_extinct(key = NULL, parse = TRUE, all = TRUE, page = 1, quiet = FALSE, ...)
 rl_extinct_(key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 }
 \arguments{
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -27,7 +27,7 @@ much burden on a server to just "get all the data" in one request.}
 or not. Default: \code{FALSE} (that is, give progress). Ignored if \code{all = FALSE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_extinct_wild.Rd
+++ b/man/rl_extinct_wild.Rd
@@ -17,10 +17,10 @@ rl_extinct_wild(
 rl_extinct_wild_(key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 }
 \arguments{
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -34,7 +34,7 @@ much burden on a server to just "get all the data" in one request.}
 or not. Default: \code{FALSE} (that is, give progress). Ignored if \code{all = FALSE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_family.Rd
+++ b/man/rl_family.Rd
@@ -21,10 +21,10 @@ rl_family_(family = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{family}{(character) The name of the family to look up. If not supplied,
 a list of all family names will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_faos.Rd
+++ b/man/rl_faos.Rd
@@ -21,10 +21,10 @@ rl_faos_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the FAO region to look up. If not
 supplied, a list of all FAO regions will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_green.Rd
+++ b/man/rl_green.Rd
@@ -10,13 +10,13 @@ rl_green(key = NULL, parse = TRUE, ...)
 rl_green_(key = NULL, ...)
 }
 \arguments{
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_growth_forms.Rd
+++ b/man/rl_growth_forms.Rd
@@ -28,10 +28,10 @@ rl_growth_forms_(
 \item{code}{(character) The code of the growth form to look up. If not
 supplied, a list of all growth forms will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -58,7 +58,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_habitats.Rd
+++ b/man/rl_habitats.Rd
@@ -21,10 +21,10 @@ rl_habitats_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the habitat to look up. If not supplied,
 a list of all habitats will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_kingdom.Rd
+++ b/man/rl_kingdom.Rd
@@ -28,10 +28,10 @@ rl_kingdom_(
 \item{kingdom}{(character) The name of the kingdom to look up. If not
 supplied, a list of all kingdom names will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -58,7 +58,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_order.Rd
+++ b/man/rl_order.Rd
@@ -21,10 +21,10 @@ rl_order_(order = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{order}{(character) The name of the order to look up. If not supplied, a
 list of all order names will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_phylum.Rd
+++ b/man/rl_phylum.Rd
@@ -21,10 +21,10 @@ rl_phylum_(phylum = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{phylum}{(character) The name of the phylum to look up. If not supplied,
 a list of all phylum names will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_pop_trends.Rd
+++ b/man/rl_pop_trends.Rd
@@ -28,10 +28,10 @@ rl_pop_trends_(
 \item{code}{(character) The code of the growth form to look up. If not
 supplied, a list of all growth forms will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -58,7 +58,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_realms.Rd
+++ b/man/rl_realms.Rd
@@ -21,10 +21,10 @@ rl_realms_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the biogeographical realm to look up. If
 not supplied, a list of all biogeographical realms will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which
@@ -59,7 +59,7 @@ case json as character string is returned.
 }
 \description{
 Get an assessment summary for a particular biogeographical realm (e.g.,
-Neotropical or Palearctic)
+Neotropical or Palearctic).
 }
 \examples{
 \dontrun{

--- a/man/rl_research.Rd
+++ b/man/rl_research.Rd
@@ -21,10 +21,10 @@ rl_research_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the research type to look up. If not
 supplied, a list of all research types will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_scopes.Rd
+++ b/man/rl_scopes.Rd
@@ -21,10 +21,10 @@ rl_scopes_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the scope to look up. If not supplied, a
 list of all scopes will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_sis.Rd
+++ b/man/rl_sis.Rd
@@ -12,13 +12,13 @@ rl_sis_(id, key = NULL, ...)
 \arguments{
 \item{id}{(integer) The SIS ID of the taxonomic entity to look up.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_sis_latest.Rd
+++ b/man/rl_sis_latest.Rd
@@ -9,13 +9,13 @@ rl_sis_latest(id, key = NULL, parse = TRUE, ...)
 \arguments{
 \item{id}{(integer) The SIS ID of the taxonomic entity to look up.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_sp_count.Rd
+++ b/man/rl_sp_count.Rd
@@ -10,16 +10,16 @@ rl_sp_count(key = NULL, ...)
 rl_sp_count_(key = NULL, ...)
 }
 \arguments{
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
-\item{...}{Curl options passed to \code{\link[crul]{HttpClient}}}
+\item{...}{Curl options passed to \link[crul:HttpClient]{HttpClient}}
 }
 \value{
 A list unless using a function with a trailing underscore, in which
 case json as character string is returned.
 }
 \description{
-Returns a count of the number of unique species which have assessments
+Returns a count of the number of unique species which have assessments.
 }
 \examples{
 \dontrun{

--- a/man/rl_species.Rd
+++ b/man/rl_species.Rd
@@ -35,13 +35,13 @@ look up.}
 \item{subpopulation}{(character) An optional name of the geographically
 separate subpopulation to look up.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_species_latest.Rd
+++ b/man/rl_species_latest.Rd
@@ -25,13 +25,13 @@ look up.}
 \item{subpopulation}{(character) An optional name of the geographically
 separate subpopulation to look up.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{...}{\link[curl:curl_options]{Curl options} passed to the GET request via
-\code{\link[crul]{HttpClient}}.}
+\link[crul:HttpClient]{cruls}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_stresses.Rd
+++ b/man/rl_stresses.Rd
@@ -21,10 +21,10 @@ rl_stresses_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the stress to look up. If not supplied, a
 list of all stresses will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_systems.Rd
+++ b/man/rl_systems.Rd
@@ -21,10 +21,10 @@ rl_systems_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the system to look up. If not supplied, a
 list of all systems will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_threats.Rd
+++ b/man/rl_threats.Rd
@@ -21,10 +21,10 @@ rl_threats_(code = NULL, key = NULL, all = TRUE, page = 1, quiet = FALSE, ...)
 \item{code}{(character) The code of the threat to look up. If not supplied, a
 list of all threats will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -51,7 +51,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_use_and_trade.Rd
+++ b/man/rl_use_and_trade.Rd
@@ -28,10 +28,10 @@ rl_use_and_trade_(
 \item{code}{(character) The code of the use and trade to look up. If not
 supplied, a list of all uses and trades will be returned.}
 
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
 \item{parse}{(logical) Whether to parse the output to list (\code{FALSE}) or,
-where possible, data.frame (\code{TRUE}). Default: \code{TRUE}}
+where possible, data.frame (\code{TRUE}). Default: \code{TRUE}.}
 
 \item{all}{(logical) Whether to retrieve all results at once or not. If
 \code{TRUE} we do the paging internally for you and bind all of the results
@@ -58,7 +58,7 @@ Europe). This is similar to the \code{region} argument of the old Red List
 API and old versions of rredlist.
 }
 Also supports any \link[curl:curl_options]{curl options} passed to the GET
-request via \code{\link[crul]{HttpClient}}.}
+request via \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
 A list unless using a function with a trailing underscore, in which

--- a/man/rl_version.Rd
+++ b/man/rl_version.Rd
@@ -7,12 +7,12 @@
 rl_version(key = NULL, ...)
 }
 \arguments{
-\item{key}{(character) An IUCN API token. See \code{\link{rl_use_iucn}}.}
+\item{key}{(character) An IUCN API token. See \code{\link[=rl_use_iucn]{rl_use_iucn()}}.}
 
-\item{...}{Curl options passed to \code{\link[crul]{HttpClient}}}
+\item{...}{Curl options passed to \link[crul:HttpClient]{HttpClient}.}
 }
 \value{
-Red List version as character string
+Red List version as character string.
 }
 \description{
 Returns the current version number of the IUCN Red List of Threatened Species

--- a/man/rredlist-package.Rd
+++ b/man/rredlist-package.Rd
@@ -17,7 +17,7 @@ need to send in every request. See key A IUCN API token. See \code{\link[=rl_use
 for help getting and storing it. Get it at
 https://api.iucnredlist.org/users/sign_up
 Keep this key private. You can pass the key in to each function via the
-\code{key} parameter, but it's better to store the key either as a
+\code{key} parameter, but it's better to store the key either as an
 environment variable (\code{IUCN_REDLIST_KEY}) or an R option
 (\code{iucn_redlist_key}) - we recommend using the former option.
 }
@@ -27,25 +27,25 @@ environment variable (\code{IUCN_REDLIST_KEY}) or an R option
 \strong{High level API}
 High level functions do the HTTP request and parse data to a data.frame for
 ease of downstream use. The high level functions have no underscore on
-the end of the function name, e.g., \code{\link[=rl_species]{rl_species()}}
+the end of the function name, e.g., \code{\link[=rl_species]{rl_species()}}.
 
 \strong{Low level API}
 The parsing to data.frame in the high level API does take extra time.
 The low level API only does the HTTP request, and gives back JSON without
 doing any more parsing. The low level functions DO have an underscore on
-the end of the function name, e.g., \code{\link[=rl_species_]{rl_species_()}}
+the end of the function name, e.g., \code{\link[=rl_species_]{rl_species_()}}.
 }
 
 \section{No Spatial}{
 
 This package does not include support for the spatial API, described at
-https://apiv3.iucnredlist.org/spatial
+https://apiv3.iucnredlist.org/spatial.
 }
 
 \section{Citing the Red List API}{
 
 Get the proper citation for the version of the Red List you are using
-by programatically running \code{\link[=rl_citation]{rl_citation()}}
+by programatically running \code{\link[=rl_citation]{rl_citation()}}.
 }
 
 \section{Red List API Terms of Use}{


### PR DESCRIPTION
## Description
This is part of my review for ropensci of the new version of the package, I thought it would be easier to do these small change as I was reviewing the package.

## Example

Add final dots, fix a few typos and replaces `\code{}` tags with their markdown equivalent, `\code{\link[crul]{HttpClient}}` becomes ` [HttpClient][crul::HttpClient()]`.

Hope this helps.